### PR TITLE
fix: clear old images before setting up new images

### DIFF
--- a/multiview/src/main/java/cn/lemon/multi/MultiView.java
+++ b/multiview/src/main/java/cn/lemon/multi/MultiView.java
@@ -211,6 +211,7 @@ public class MultiView extends ViewGroup {
      * 网络图片地址
      */
     public void setImages(List<String> data) {
+        clear();
         isImageURL = true;
         mData = data;
         if (data.size() > 9) {


### PR DESCRIPTION
In the `RecyclerView`, if a drop-down refresh is used, the images will be added to an item multiple times. Therefore, it is necessary to  execute `clear()` once to clear the old data before executing 'setImages()'.

> 在 `RecyclerView` 中， 如果使用了下拉刷新，则会在一个 `item` 中多次添加图片。因此需要在执行 `setImages()` 之前，先执行一次 `clear()` 清除原来的旧数据.